### PR TITLE
インクリメンタルサーチの実装

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,66 @@
+$(function() {
+  function addUser(user) {
+    let html = `
+                <div class="ChatMember">
+                  <p class="ChatMember__name">${user.name}</p>
+                  <div class="ChatMember__add ChatMember__button" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+                </div>
+                `;
+    $("#UserSearchResult").append(html);
+  }
+
+  function addNoUser() {
+    let html = `
+                <div class="ChatMember">
+                  <p class="ChatMember__name">ユーザーが見つかりません</p>
+                </div>
+                `;
+    $("#UserSearchResult").append(html);
+  }
+
+  function addMember(name, id) {
+    let html =`
+                <div class="ChatMember">
+                  <p class="ChatMember__name">${name}</p>
+                  <input name="group[user_ids][]" type="hidden" value="${id}" />
+                  <div class="ChatMember__remove ChatMember__button">削除</div>
+                </div>
+                `;
+    $(".ChatMembers").append(html);
+  }
+  $("#UserSearch__field").on("keyup", function(){
+    let input = $("#UserSearch__field").val();
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input },
+      dataType: 'json'
+    })
+    .done(function(users){
+      $("#UserSearchResult").empty();
+      if (users.length !== 0) {
+        users.forEach(function(user){
+          addUser(user);
+        });
+      } else if (input.length == 0) {
+        return false;
+      } else {
+        addNoUser();
+      }
+    })
+    .fail(function(){
+      alert("通信エラーです。ユーザーが表示できません。");
+    });
+  });
+
+  $("#UserSearchResult").on("click", ".ChatMember__add", function(){
+    const userName = $(this).attr("data-user-name");
+    const userId = $(this).attr("data-user-id");
+    $(this).parent().remove();
+    addMember(userName, userId);
+  });
+
+  $(".ChatMembers").on("click", ".ChatMember__remove", function(){
+    $(this).parent().remove();
+  });
+});

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -40,18 +40,22 @@
   &__groups {
     height: calc(100vh - 100px);
     background-color: #2f3e51;
+    overflow: scroll;
     &__group {
       padding: 20px 20px 40px 20px;
-      &__name {
-        font-size: 15px;
-        color: $sidebar-color;
-        font-weight: bold;
-        margin-bottom: 5px;
-      }
-      &__message {
-        font-size: 11px;
-        color: $sidebar-color;
-        font-weight: bold;
+      &__link {
+        text-decoration: none;
+        &__name {
+          font-size: 15px;
+          color: $sidebar-color;
+          font-weight: bold;
+          margin-bottom: 5px;
+        }
+        &__message {
+          font-size: 11px;
+          color: $sidebar-color;
+          font-weight: bold;
+        }
       }
     }
   }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,14 @@
 class UsersController < ApplicationController
 
+  def index
+    return nil if params[:keyword] == ""
+    @users = User.where(['name LIKE ?', "%#{params[:keyword]}%"]).where.not(id: current_user.id).limit(10)
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   def edit
   end
 

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -14,9 +14,24 @@
     .SettingGroupForm__leftField
       %label.SettingGroupForm__label チャットメンバーを追加
     .SettingGroupForm__rightField
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      .UserSearch
+        %input#UserSearch__field.SettingGroupForm__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}/
+      #UserSearchResult
+  .SettingGroupForm__field
+    .SettingGroupForm__leftField
+      = f.label :name, value: "チャットメンバー", class: "SettingGroupForm__label"
+    .SettingGroupForm__rightField
+      .ChatMembers
+        .ChatMember
+          %p.ChatMember__name= current_user.name
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+        - group.users.each do |user|
+          - if current_user.name != user.name
+            .ChatMember
+              %p.ChatMember__name
+                = user.name
+              .ChatMember__remove.ChatMember__button{"data-user-id": user.id, "data-user-name": user.name} 削除
+              %input{name: "group[user_ids][]", type:"hidden", value: user.id}
   .SettingGroupForm__field
     .SettingGroupForm__leftField
     .SettingGroupForm__rightField

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -12,8 +12,8 @@
   .Side-bar__groups
     - current_user.groups.each do |group|
       .Side-bar__groups__group
-        = link_to group_messages_path(group) do
-          .Side-bar__groups__group__name
+        = link_to group_messages_path(group), class: 'Side-bar__groups__group__link' do
+          .Side-bar__groups__group__link__name
             = group.name
-          .Side-bar__groups__group__message
+          .Side-bar__groups__group__link__message
             = group.show_last_message

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "groups#index"
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
# What
グループの新規・編集画面で、ユーザーがインクリメンタルサーチされるように実装した。
その他、インクリメンタルサーチ後についても下記を実装した。
・追加ボタンが押された時にイベントが発火するようにする
・チャットメンバーのところに追加されたユーザーの名前を追加、検索結果からは消えるようにする
・削除ボタンを押すとチャットメンバーから消えるようにする
・編集画面では既に追加済みのメンバーが表示されるようにしてある
注意)
現時点では、検索を行うとメンバーに既に追加済みのユーザーも検索結果に出てきてしまう。
これを避けるようにする実装は、ChatSpaceの全ての実装が終わった後に行う。(予定)

#  Why
グループの新規・編集画面でメンバー編集をしやすくするため